### PR TITLE
Update tooling

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,28 @@
+engines:
+  duplication:
+    enabled: true
+    config:
+      languages:
+      - ruby
+      - javascript
+      - python
+      - php
+  fixme:
+    enabled: true
+  phpmd:
+    enabled: true
+    checks:
+      Controversial/CamelCaseClassName:
+        enabled: false
+      Controversial/CamelCaseVariableName:
+        enabled: false
+ratings:
+  paths:
+  - "**.inc"
+  - "**.js"
+  - "**.jsx"
+  - "**.module"
+  - "**.php"
+  - "**.py"
+  - "**.rb"
+exclude_paths: []

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Status
+_Use labels (`review needed`, `in progress`, or `paused`) to declare status_
+
+#### What does this PR do?
+A few sentences describing the overall goals of the pull request's commits.
+Why are we making these changes? Is there more work to be done to fully
+achieve these goals?
+
+#### Helpful background context (if appropriate)
+
+#### How can a reviewer manually see the effects of these changes?
+
+#### What are the relevant tickets?
+- https://mitlibraries.atlassian.net/browse/NTI-
+
+#### Screenshots (if appropriate)
+
+#### Todo:
+- [ ] Documentation
+- [ ] Stakeholder approval
+
+#### Requires new or updated plugins, themes, or libraries?
+YES | NO
+
+#### Requires change to deploy process?
+YES | NO

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+*.
+lib-cov
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+*.DS_Store
+
+pids
+logs
+results
+_notes
+
+# local CodeSniffer check
+codesniffer.local.xml
+
+# Sublime workspace
+*.sublime-workspace

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,112 @@
+# Travis CI (MIT License) configuration file for a WordPress plugin.
+# @link https://travis-ci.org/
+
+# For use with the MIT Libraries' pending posts plugin.
+# @link https://github.com/MITLibraries/wp-pending-posts
+
+# Declare what Travis environment should be used. Specifically, we need the
+# 'precise' environment rather than 'trusty' to get PHP 5.3.
+dist: precise
+
+# Declare project language.
+# @link http://about.travis-ci.org/docs/user/languages/php/
+language: php
+
+# Declare versions of PHP to use. Use one decimal max.
+php:
+  # aliased to a recent 7.1.x version
+  - "7.1"
+  # aliased to a recent 5.6.x version
+  - "5.6"
+  # aliased to a recent 5.3.x version
+  - "5.3"
+
+# Declare which versions of WordPress to test against.
+# Also declare whether or not to test in Multisite.
+env:
+  # Trunk
+  # @link https://github.com/WordPress/WordPress
+  # WP_VERSION=master WP_MULTISITE=0
+  - WP_VERSION=master WP_MULTISITE=1
+  # WordPress 4.8
+  # @link https://github.com/WordPress/WordPress/tree/4.8-branch
+  # WP_VERSION=4.8 WP_MULTISITE=0
+  - WP_VERSION=4.8 WP_MULTISITE=1
+
+# Declare "future" releases to be acceptable failures.
+# @link https://buddypress.trac.wordpress.org/ticket/5620
+# @link http://docs.travis-ci.com/user/build-configuration/
+matrix:
+  allow_failures:
+    - php: "7.1"
+    - php: "5.6"
+    - env: WP_VERSION=master WP_MULTISITE=1
+  fast_finish: true
+
+# Use this to prepare the system to install prerequisites or dependencies.
+# e.g. sudo apt-get update.
+# Failures in this section will result in build status 'errored'.
+# before_install:
+
+# Use this to prepare your build for testing.
+# e.g. copy database configurations, environment variables, etc.
+# Failures in this section will result in build status 'errored'.
+before_script:
+  # Set up WordPress installation.
+  - export WP_DEVELOP_DIR=/tmp/wordpress/
+  - mkdir -p $WP_DEVELOP_DIR
+  # Use the Git mirror of WordPress.
+  - git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ $WP_DEVELOP_DIR
+  # Set up plugin information.
+  - plugin_slug=$(basename $(pwd))
+  - plugin_dir=$WP_DEVELOP_DIR/src/wp-content/plugins/$plugin_slug
+  - cd ..
+  - mv $plugin_slug $plugin_dir
+  # Set up WordPress configuration.
+  - cd $WP_DEVELOP_DIR
+  - echo $WP_DEVELOP_DIR
+  - cp wp-tests-config-sample.php wp-tests-config.php
+  - sed -i "s/youremptytestdbnamehere/wordpress_test/" wp-tests-config.php
+  - sed -i "s/yourusernamehere/root/" wp-tests-config.php
+  - sed -i "s/yourpasswordhere//" wp-tests-config.php
+  # Create WordPress database.
+  - mysql -e 'CREATE DATABASE wordpress_test;' -uroot
+  # Install CodeSniffer for WordPress Coding Standards checks.
+  - git clone https://github.com/squizlabs/PHP_CodeSniffer.git php-codesniffer
+  # Install WordPress Coding Standards.
+  - git clone https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards.git wordpress-coding-standards
+  # Hop into CodeSniffer directory.
+  - cd php-codesniffer
+  # Checkout pre 3.x version
+  - git checkout tags/2.9.1
+  # Set install path for WordPress Coding Standards.
+  # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
+  - scripts/phpcs --config-set installed_paths ../wordpress-coding-standards
+  # Hop into plugins directory.
+  - cd $plugin_dir
+  # After CodeSniffer install you should refresh your path.
+  - phpenv rehash
+
+# Run test script commands.
+# Default is specific to project language.
+# All commands must exit with code 0 on success. Anything else is considered failure.
+script:
+  # Search for PHP syntax errors.
+  - find . \( -name '*.php' \) -exec php -lf {} \;
+  # WordPress Coding Standards
+  # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+  # @link http://pear.php.net/package/PHP_CodeSniffer/
+  # -p flag: Show progress of the run.
+  # -s flag: Show sniff codes in all reports.
+  # -v flag: Print verbose output.
+  # -n flag: Do not print warnings. (shortcut for --warning-severity=0)
+  # --standard: Use WordPress as the standard.
+  # --extensions: Only sniff PHP files.
+  # --report=source: Return summary table
+  # --report=full: Returns verbose list of problems by test and line
+  - $WP_DEVELOP_DIR/php-codesniffer/scripts/phpcs -p -s -v -n . --standard=./codesniffer.ruleset.xml --extensions=php --report=source --report=full
+
+# Receive notifications for build results.
+# @link http://docs.travis-ci.com/user/notifications/#Email-notifications
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-wp-pending-posts
-================
+# Pending Posts
+
+[![Build Status](https://travis-ci.org/MITLibraries/wp-pending-posts.svg?branch=master)](https://travis-ci.org/MITLibraries/wp-pending-posts)
+[![Code Climate](https://codeclimate.com/github/MITLibraries/wp-pending-posts/badges/gpa.svg)](https://codeclimate.com/github/MITLibraries/wp-pending-posts)
+[![Issue Count](https://codeclimate.com/github/MITLibraries/wp-pending-posts/badges/issue_count.svg)](https://codeclimate.com/github/MITLibraries/wp-pending-posts)
 
 A WordPress plugin that displays a list of pending posts, in a dashboard widget, for admin-level users.

--- a/class-pending-posts-widget.php
+++ b/class-pending-posts-widget.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * Class that defines a "pending posts" dashboard widget.
+ *
+ * @package WP Pending Posts
+ * @since 1.0.0
+ */
+
+namespace mitlib;
+
+/**
+ * Defines base widget
+ */
+class Pending_Posts_Widget {
+
+	/**
+	 * The id of this widget.
+	 */
+	const WID = 'pending_posts';
+
+	/**
+	 * Hook to wp_dashboard_setup to add the widget.
+	 */
+	public static function init() {
+		wp_add_dashboard_widget(
+			self::WID, // A unique slug/ID
+			'Urgent and/or pending posts', // Visible name for the widget.
+			array( 'mitlib\Pending_Posts_Widget', 'widget' )  // Callback for the main widget content.
+		);
+	}
+
+	/**
+	 * Loads custom stylesheet.
+	 */
+	public static function styles() {
+		wp_register_style( 'pending_styles', plugin_dir_url( __FILE__ ) . 'wp-pending-posts.css', false, '1.0.0' );
+		wp_enqueue_style( 'pending_styles' );
+	}
+
+	/**
+	 * Load the widget code.
+	 *
+	 * The widget runs two queries in order to avoid a performance penalty using complex sorts.
+	 * The first query looks for pending posts that are _also_ marked "urgent". The second query
+	 * looks for pending posts that are _not_ marked "urgent".
+	 *
+	 * In an ideal world this query would be written along the lines of:
+	 * SELECT posts
+	 * WHERE post_status = 'pending'
+	 * ORDER BY meta_value DESC, title ASC
+	 */
+	public static function widget() {
+		// Define the basic query arguments array. This will then be slightly modified ahead of each query.
+		$args = array(
+			'post_type' => 'any',
+			'orderby' => 'title',
+			'order' => 'ASC',
+			'post_status' => 'pending',
+			'posts_per_page' => 10,
+			'meta_key' => 'urgent',
+		);
+
+		// The first query looks for pending posts _with_ the urgent flag.
+		$args['meta_value'] = 1;
+		$urgent = new \WP_Query( $args );
+
+		// The second query looks for pending posts _without_ the urgent flag.
+		$args['meta_value'] = 0;
+		$pending = new \WP_Query( $args );
+
+		// Use the template to render widget output.
+		require_once( 'widget.php' );
+
+		// Reset post data.
+		$urgent = null;
+		$pending = null;
+		wp_reset_postdata();
+
+	}
+}

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Theme Coding Standards">
+	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
+
+	<!-- Set a description for this ruleset. -->
+	<description>A custom set of code standard rules to check for WordPress plugins.</description>
+
+	<!-- Include the WordPress ruleset, with exclusions. -->
+	<rule ref="WordPress">
+		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
+		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
+		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
+	</rule>
+</ruleset>

--- a/widget.php
+++ b/widget.php
@@ -21,7 +21,7 @@ if ( $urgent->have_posts() ) {
 		// Add the 'form-invalid' class to all urgent post listings so they appear red.
 		$urgent->the_post();
 	?>
-		<tr class="form-invalid">
+		<tr class="urgent">
 			<td class="row-title">
 				<a href="<?php echo esc_url( get_edit_post_link() ); ?>">
 					<?php echo esc_html( get_the_title() ); ?>

--- a/widget.php
+++ b/widget.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * The template for the urgent / pending posts widget.
+ *
+ * @package WP Pending Posts
+ * @since 1.0.0
+ */
+
+?>
+<table class="widefat">
+	<thead>
+		<tr>
+			<th class="row-title" scope="col">Title</th>
+			<th>Author</th>
+		</tr>
+	</thead>
+	<tbody>
+<?php
+if ( $urgent->have_posts() ) {
+	while ( $urgent->have_posts() ) {
+		// Add the 'form-invalid' class to all urgent post listings so they appear red.
+		$urgent->the_post();
+	?>
+		<tr class="form-invalid">
+			<td class="row-title">
+				<a href="<?php echo esc_url( get_edit_post_link() ); ?>">
+					<?php echo esc_html( get_the_title() ); ?>
+				</a>
+			</td>
+			<td><?php echo esc_html( get_the_author() ); ?></td>
+		</tr>
+	<?php
+	}
+} else {
+	?>
+		<tr>
+			<td colspan="2">There are no urgent posts.</td>
+		</tr>	
+	<?php
+}
+?>
+<?php
+if ( $pending->have_posts() ) {
+	while ( $pending->have_posts() ) {
+		$pending->the_post();
+	?>
+		<tr>
+			<td class="row-title">
+				<a href="<?php echo esc_url( get_edit_post_link() ); ?>">
+					<?php echo esc_html( get_the_title() ); ?>
+				</a>
+			</td>
+			<td><?php echo esc_html( get_the_author() ); ?></td>
+		</tr>
+	<?php
+	}
+} else {
+	?>
+		<tr>
+			<td colspan="2">There are no pending posts.</td>
+		</tr>	
+	<?php
+}
+?>
+	</tbody>
+</table>

--- a/wp-pending-posts.css
+++ b/wp-pending-posts.css
@@ -1,0 +1,3 @@
+tr.urgent {
+	background-color: rgb(255,235,232);
+}

--- a/wp-pending-posts.php
+++ b/wp-pending-posts.php
@@ -24,5 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Include the necessary classes.
 include_once( 'class-pending-posts-widget.php' );
 
+// Load the widget styles.
+add_action( 'admin_enqueue_scripts', array( 'mitlib\Pending_Posts_Widget', 'styles' ) );
+
 // Call the class' init method as part of dashboard setup.
 add_action( 'wp_dashboard_setup', array( 'mitlib\Pending_Posts_Widget', 'init' ) );

--- a/wp-pending-posts.php
+++ b/wp-pending-posts.php
@@ -1,105 +1,28 @@
 <?php
 /**
  * Plugin Name:   WP Pending Posts
- * Plugin URI:    https://github.com/zgreen/wp-pending-posts
- * Text Domain:   wpzgreen_pending_posts
- * Domain Path:   /languages
+ * Plugin URI:    https://github.com/MITLibraries/wp-pending-posts
  * Description:   Displays a "Pending posts" dashboard widget for admin-level users.
- * Author:        Zach Green
- * Version:       0.1.0
+ * Version:       1.0.0
+ * Author:        MIT Libraries
+ * Author URI:    https://github.com/MITLibraries
  * Licence:       GPL2
- * Author URI:    http://zgreen.github.io
- * Last Change:   10/08/2014
+ *
+ * @package WP Pending Posts
+ * @since 0.1.0
+ * @author MIT Libraries
+ * @link https://github.com/MITLibraries/wp-pending-posts
  */
 
-defined('ABSPATH') or die("No script kiddies, please!");
+namespace mitlib;
 
-// Add dashboard widgets
-function wpzgreen_add_pending_widget() {
-	// Add a pending posts dashboard widget
-	wp_add_dashboard_widget(
-		'wpzgreen_pending_dashboard_widget',         // Widget slug.
-		'Urgent and/or pending posts',         // Title.
-		'wpzgreen_pending_dashboard_widget_function' // Display function.
-	);
+// Don't call the file directly!
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
 }
 
-add_action( 'wp_dashboard_setup', 'wpzgreen_add_pending_widget' );
+// Include the necessary classes.
+include_once( 'class-pending-posts-widget.php' );
 
-// Build the Pending posts dashboard widget
-function wpzgreen_pending_dashboard_widget_function() {
-
-	$args_urgent = array(
-	  'post_type' => 'any',
-	  'orderby'   => 'title',
-	  'order'     => 'ASC',
-	  'post_status' => 'pending',
-	  'posts_per_page' => 10,
-	  'meta_key'		=> 'urgent',
-		'meta_value'		=> 1
-	);
-
-	$args_pending = array(
-	  'post_type' => 'any',
-	  'orderby'   => 'title',
-	  'order'     => 'ASC',
-	  'post_status' => 'pending',
-	  'posts_per_page' => 10,
-	  'meta_key'		=> 'urgent',
-		'meta_value'		=> 0
-	);
-
-	$urgent_posts = new WP_Query ( $args_urgent );
-
-	echo  '<table class="widefat">' .
-						'<thead>' .
-							'<tr>' .
-								'<th class="row-title">Post title</th>' .
-								'<th>Post author</th>' .
-							'</tr>' .
-						'</thead>' .
-						'<tbody>';
-
-	// The Loops
-	if ( $urgent_posts->have_posts() ) {
-		
-		while ( $urgent_posts->have_posts() ) {
-			$urgent_posts->the_post();
-			echo  '<tr class="form-invalid">' .
-							'<td class="row-title"><a href="' . get_edit_post_link() . '">' . get_the_title() . '</a></td>' .
-							'<td>' . get_the_author() . '</td>' .
-						'</tr>';
-		}
-	} else {
-		echo 	'<tr>' .
-						'<td>There are no urgent posts</td>' .
-					'</tr>';
-	}
-
-	wp_reset_postdata();
-
-	$pending_posts = new WP_Query( $args_pending );
-
-	if ( $pending_posts->have_posts() ) {
-		while ( $pending_posts->have_posts() ) {
-			$pending_posts->the_post();
-			echo  '<tr>' .
-							'<td class="row-title"><a href="' . get_edit_post_link() . '">' . get_the_title() . '</a></td>' .
-							'<td>' . get_the_author() . '</td>' .
-						'</tr>';
-		}
-		echo    '</tbody>' .
-					'</table>';
-	} else {
-		echo '<tr>' .
-						'<td>There are no pending posts</td>' .
-					'</tr>' .
-				'</tbody>' .
-			'</table>';
-	}
-
-	wp_reset_postdata();
-	
-}
-
-?>
+// Call the class' init method as part of dashboard setup.
+add_action( 'wp_dashboard_setup', array( 'mitlib\Pending_Posts_Widget', 'init' ) );


### PR DESCRIPTION
## Status
_Use labels (`review needed`, `in progress`, or `paused`) to declare status_

#### What does this PR do?
This work does two things:
- [x] Applies the usual tooling updates that we've been doing for all other WordPress code the last week or so
- [x] Refactors the plugin to make use of current best practices, and to make its codebase similar to related plugins like MITLibraries/wp-home-page-news.

#### Helpful background context (if appropriate)
If the structure of this new code needs context, look at the wp-home-page-news plugin, and the reference dashboard widget example at https://codex.wordpress.org/Example_Dashboard_Widget

#### How can a reviewer manually see the effects of these changes?
The tooling updates will only be visible on GitHub, in that the linters should all pass. In the case of this particular branch, we don't even add anything to the whitelist - the refactor addresses all code violations.

The refactor itself slightly changes the widget interface, in that field labels change. Also, we re-introduce the lost feature of highlighting urgent posts in red.

#### What are the relevant tickets?
- https://mitlibraries.atlassian.net/browse/NTI-158

#### Screenshots (if appropriate)
Before:
![image](https://user-images.githubusercontent.com/1403248/30500475-763594d8-9a2c-11e7-9926-aa1f3d03d983.png)

After:
![image](https://user-images.githubusercontent.com/1403248/30500480-7aca6168-9a2c-11e7-9ab8-24914b7ce985.png)

#### Todo:
- [x] Stakeholder approval

#### Requires new or updated plugins, themes, or libraries?
NO

#### Requires change to deploy process?
NO
